### PR TITLE
Fix (hopefully transient) build issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ log = "0.4"
 failure = "0.1"
 failure_derive = "0.1"
 newtype_derive = "0.1"
+quote = "=1.0.2"
 
 [features]
 default=[]


### PR DESCRIPTION
Due to an issue with the 'quote' crate at the moment, its version must
be fixed in the Cargo.toml file. See this thread:

https://users.rust-lang.org/t/failure-derive-compilation-error/39062