### PR TITLE
Update the version and README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bardecoder"
-version = "0.2.0"
+version = "0.2.3"
 authors = ["Mark Arts <piderman+github@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Add the following to your `Cargo.toml`:
 
 ``` toml
 [dependencies]
-bardecoder = "0.2.1"
-image = "0.22"
+bardecoder = "0.2.3"
+image = "0.23"
 ```
 
 ### Quick


### PR DESCRIPTION
My local build of my other project was complaining that the version of bardecoder was still listed as 0.2.0 instead of 0.2.2.  This bumps it to 0.2.3 (under the assumption that that's what the next release would be) as well as updates the README for the version and for the image dependency.

At least this way I can specify the 0.2.2 version number properly in a local build.  :)