### PR TITLE
Fix crash on ios.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ Detect and decode QR Codes
 """
 
 [dependencies]
+anyhow = "1.0.66"
 image = ">= 0.23.14, < 0.24"
 log = "0.4"
-failure = "0.1"
-failure_derive = "0.1"
 newtype_derive = "0.1"
+thiserror = "1.0.37"
 
 [features]
 default=[]

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -1,7 +1,5 @@
 //! Decode data extracted from an image
 
-use failure::Fail;
-
 mod qr;
 
 pub use self::qr::decoder::{QRDecoder, QRDecoderWithInfo};
@@ -38,10 +36,7 @@ pub use self::qr::decoder::{QRDecoder, QRDecoderWithInfo};
 /// [`here`]: ../extract/trait.Extract.html
 /// [`Decoder`]: ../struct.Decoder.html
 
-pub trait Decode<DATA, RESULT, ERROR>
-where
-    ERROR: Fail,
-{
+pub trait Decode<DATA, RESULT, ERROR> {
     /// Does the actual decoding
     fn decode(&self, data: Result<DATA, ERROR>) -> Result<RESULT, ERROR>;
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,7 +1,6 @@
+use anyhow::Error;
 use image::DynamicImage;
 use image::GrayImage;
-
-use failure::Error;
 
 use crate::decode::{Decode, QRDecoder, QRDecoderWithInfo};
 use crate::detect::{Detect, LineScan, Location};

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -1,7 +1,5 @@
 //! Extract data from an image
 
-use failure::Fail;
-
 mod qr;
 
 pub use self::qr::QRExtractor;
@@ -41,10 +39,7 @@ pub use self::qr::QRExtractor;
 /// [`Detect`]: ../detect/trait.Detect.html
 /// [`Prepare`]: ../prepare/trait.Prepare.html
 /// [`here`]: ../decode/trait.Decode.html
-pub trait Extract<PREPD, LOC, DATA, ERROR>
-where
-    ERROR: Fail,
-{
+pub trait Extract<PREPD, LOC, DATA, ERROR> {
     /// Does the actual extracting
     fn extract(&self, prepared: &PREPD, loc: LOC) -> Result<DATA, ERROR>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,6 @@
 extern crate log;
 
 #[macro_use]
-extern crate failure_derive;
-
-#[macro_use]
 extern crate newtype_derive;
 
 mod decoder;

--- a/src/util/qr.rs
+++ b/src/util/qr.rs
@@ -1,14 +1,14 @@
 //! Utility structs for decoding QR Codes
 
 use std::ops::Index;
-
 use std::string::FromUtf8Error;
+use thiserror::Error;
 
 use crate::util::Point;
 
 /// Generic QR Error message. Can be converted into `failure::Error`
-#[derive(Fail, Debug, Clone, PartialEq, Eq)]
-#[fail(display = "Error decoding QR Code: {}", msg)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[error("Error decoding QR Code: {}", msg)]
 pub struct QRError {
     /// Detail message
     pub msg: String,

--- a/tests/image_tests.rs
+++ b/tests/image_tests.rs
@@ -1,4 +1,4 @@
-use failure::Error;
+use anyhow::Error;
 
 use bardecoder::{ECLevel, QRInfo};
 


### PR DESCRIPTION
not sure why exactly `failure::Error::from()` caused some crash on ios, but since `failure` has been deprecated for a while updated to `thiserror`.